### PR TITLE
feat: use exoplayer, hybrid composition

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'me.albemala.native_video_player'
 version '1.0.0'
 
 buildscript {
-    ext.kotlin_version = "1.8.22"
+    ext.kotlin_version = '2.0.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("com.android.tools.build:gradle:8.1.4")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -50,6 +50,6 @@ android {
 
 }
 
-// dependencies {
-//     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-// }
+ dependencies {
+     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+ }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,5 +53,4 @@ android {
  dependencies {
      implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
      implementation("androidx.media3:media3-exoplayer:1.5.0")
-     implementation("androidx.media3:media3-ui:1.5.0")
  }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,8 @@ android {
     defaultConfig {
         minSdkVersion 21
     }
+
+    namespace 'me.albemala.native_video_player'
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
       namespace = "me.albemala.native_video_player"
     }
 
-    compileSdk = 34
+    compileSdk = 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,15 +2,15 @@ group 'me.albemala.native_video_player'
 version '1.0.0'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = "1.8.22"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
@@ -25,8 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
-    namespace "me.albemala.native_video_player"
+    if (project.android.hasProperty("namespace")) {
+      namespace = "me.albemala.native_video_player"
+    }
+
+    compileSdk = 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -42,12 +45,11 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk = 21
     }
 
-    namespace 'me.albemala.native_video_player'
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}
+// dependencies {
+//     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+// }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,12 +32,12 @@ android {
     compileSdk = 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -52,4 +52,6 @@ android {
 
  dependencies {
      implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+     implementation("androidx.media3:media3-exoplayer:1.5.0")
+     implementation("androidx.media3:media3-ui:1.5.0")
  }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -80,11 +80,11 @@ class NativeVideoPlayerViewController(
 
     override fun getVideoInfo(): VideoInfo {
         val videoSize = player.videoSize
-        return VideoInfo(videoSize.height, videoSize.width, player.duration.toInt())
+        return VideoInfo(videoSize.height, videoSize.width, player.duration.toInt() / 1000)
     }
 
     override fun getPlaybackPosition(): Int {
-        return player.currentPosition.toInt()
+        return player.currentPosition.toInt() / 1000
     }
 
     override fun play() {
@@ -104,7 +104,7 @@ class NativeVideoPlayerViewController(
     }
 
     override fun seekTo(position: Int) {
-        player.seekTo(position.toLong())
+        player.seekTo(position.toLong() * 1000)
     }
 
     override fun setPlaybackSpeed(speed: Double) {

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -1,6 +1,7 @@
 package me.albemala.native_video_player
 
 import android.content.Context
+import android.view.SurfaceView
 import android.view.View
 import android.widget.RelativeLayout
 import androidx.annotation.OptIn
@@ -11,7 +12,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
-import androidx.media3.ui.PlayerView
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.platform.PlatformView
 import me.albemala.native_video_player.platform_interface.*
@@ -26,26 +26,26 @@ class NativeVideoPlayerViewController(
     Player.Listener {
 
     private val player: ExoPlayer
-    private val view: PlayerView
+    private val view: SurfaceView
     private val relativeLayout: RelativeLayout
 
     init {
         api.delegate = this
         player = ExoPlayer.Builder(context).build()
-        view = PlayerView(context)
-        view.player = player
-        view.setBackgroundColor(0)
         player.addListener(this)
 
+        view = SurfaceView(context)
+        view.setBackgroundColor(0)
         val layoutParams = RelativeLayout.LayoutParams(
             RelativeLayout.LayoutParams.MATCH_PARENT,
             RelativeLayout.LayoutParams.MATCH_PARENT
         )
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP)
+        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
+        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
         view.layoutParams = layoutParams
+        player.setVideoSurfaceView(view)
 
         relativeLayout = RelativeLayout(context)
         relativeLayout.layoutParams = RelativeLayout.LayoutParams(

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -65,7 +65,8 @@ class NativeVideoPlayerViewController(
         player.release()
     }
 
-    @OptIn(UnstableApi::class) override fun loadVideoSource(videoSource: VideoSource) {
+    @OptIn(UnstableApi::class)
+    override fun loadVideoSource(videoSource: VideoSource) {
         val mediaItem = MediaItem.fromUri(videoSource.path)
         when (videoSource.type) {
             VideoSourceType.Asset, VideoSourceType.File -> player.setMediaItem(mediaItem)
@@ -113,6 +114,10 @@ class NativeVideoPlayerViewController(
 
     override fun setVolume(volume: Double) {
         player.volume = volume.toFloat()
+    }
+
+    override fun setLoop(loop: Boolean) {
+        player.repeatMode = if (loop) Player.REPEAT_MODE_ALL else Player.REPEAT_MODE_OFF
     }
 
     override fun onPlaybackStateChanged(@Player.State state: Int) {

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewFactory.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewFactory.kt
@@ -16,7 +16,7 @@ class NativeVideoPlayerViewFactory(
     }
 
     override fun create(
-        context: Context?,
+        context: Context,
         viewId: Int,
         args: Any?
     ): PlatformView {

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
@@ -15,6 +15,7 @@ interface NativeVideoPlayerApiDelegate {
     fun seekTo(position: Int)
     fun setPlaybackSpeed(speed: Double)
     fun setVolume(volume: Double)
+    fun setLoop(loop: Boolean)
 }
 
 const val invalidArgumentsErrorCode = "invalid_argument"
@@ -99,6 +100,12 @@ class NativeVideoPlayerApi(
                 val volume = methodCall.arguments as? Double
                     ?: return result.error(invalidArgumentsErrorCode, invalidArgumentsErrorMessage, null)
                 delegate?.setVolume(volume)
+                result.success(null)
+            }
+            "setLoop" -> {
+                val loop = methodCall.arguments as? Boolean
+                    ?: return result.error(invalidArgumentsErrorCode, invalidArgumentsErrorMessage, null)
+                delegate?.setLoop(loop)
                 result.success(null)
             }
             else -> {

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoInfo.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoInfo.kt
@@ -5,7 +5,7 @@ data class VideoInfo(
     val width: Int,
     val duration: Int
 ) {
-    fun toMap(): Map<String, Any> = mapOf(
+    fun toMap(): Map<String, Int> = mapOf(
         "height" to height,
         "width" to width,
         "duration" to duration

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoSource.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoSource.kt
@@ -17,8 +17,7 @@ data class VideoSource(
                     headersAny.entries
                     .filter { it.key is String && it.value is String }
                     .associate { (it.key as String) to (it.value as String) }
-            val type = VideoSourceType
-                .values()
+            val type = VideoSourceType.entries
                 .firstOrNull {
                     it.value == typeValue
                 }

--- a/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
+++ b/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
@@ -9,9 +9,11 @@ protocol NativeVideoPlayerApiDelegate: AnyObject {
     func seekTo(position: Int, completion: @escaping () -> Void)
     func setPlaybackSpeed(speed: Double)
     func setVolume(volume: Double)
+    func setLoop(loop: Bool)
 }
 
-let invalidArgumentsFlutterError = FlutterError(code: "invalid_argument", message: "Invalid arguments", details: nil)
+let invalidArgumentsFlutterError = FlutterError(
+    code: "invalid_argument", message: "Invalid arguments", details: nil)
 
 class NativeVideoPlayerApi {
     weak var delegate: NativeVideoPlayerApiDelegate?
@@ -99,6 +101,13 @@ class NativeVideoPlayerApi {
                 return
             }
             delegate?.setVolume(volume: volume)
+            result(nil)
+        case "setLoop":
+            guard let loop = call.arguments as? Bool else {
+                result(invalidArgumentsFlutterError)
+                return
+            }
+            delegate?.setLoop(loop: loop)
             result(nil)
         default:
             result(FlutterMethodNotImplemented)

--- a/lib/src/native_video_player_controller.dart
+++ b/lib/src/native_video_player_controller.dart
@@ -51,9 +51,7 @@ class NativeVideoPlayerController with ChangeNotifier {
 
   /// Emitted when a playback error occurs
   /// or when it's not possible to load the video source
-  final onError = ValueNotifier<String?>(
-    null,
-  );
+  final onError = ValueNotifier<String?>(null);
 
   /// The video source that is currently loaded.
   VideoSource? get videoSource => _videoSource;
@@ -91,7 +89,7 @@ class NativeVideoPlayerController with ChangeNotifier {
   }
 
   Future<void> _onPlaybackEnded() async {
-    await stop();
+    onPlaybackStatusChanged.value = PlaybackStatus.stopped;
     onPlaybackEnded.notifyListeners();
   }
 
@@ -207,6 +205,11 @@ class NativeVideoPlayerController with ChangeNotifier {
     await _api.setVolume(volume);
     _volume = volume;
     onVolumeChanged.value = volume;
+  }
+
+  // ignore: avoid_positional_boolean_parameters
+  Future<void> setLoop(bool loop) {
+    return _api.setLoop(loop);
   }
 
   void _startPlaybackPositionTimer() {

--- a/lib/src/platform_interface/native_video_player_api.dart
+++ b/lib/src/platform_interface/native_video_player_api.dart
@@ -104,4 +104,12 @@ class NativeVideoPlayerApi {
       speed,
     );
   }
+
+  // ignore: avoid_positional_boolean_parameters
+  Future<void> setLoop(bool loop) async {
+    await _channel.invokeMethod<bool>(
+      'setLoop',
+      loop,
+    );
+  }
 }


### PR DESCRIPTION
### Description

This PR overhauls the Android implementation to use Exoplayer instead of MediaPlayer and changes the rendering mode to hybrid composition for HDR support (same as iOS). This allows for smoother playback and seeking as well as faster initialization. Additionally, I was unable to use hybrid composition with MediaPlayer's VideoView, but it works with Exoplayer without issue.

It also makes some other adjustments. Looping is now natively supported and managed as it worked better than handling it in Dart from my testing. Playback completion now only sets the "stopped" status in Dart without releasing video resources - this caused issues with Exoplayer. `onPlaybackEnded` is only called when the video actually stops playing - looping does not fire this event. This removes the guesswork on the listening side as to whether the UI should be updated or if the video is just going to start again.