### PR TITLE
Add HLS & DASH support for Immich app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+- Added HLS and MPEG-DASH support
+
 ## 1.3.1
 
 - Fixed #10 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,4 +53,6 @@ android {
  dependencies {
      implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
      implementation("androidx.media3:media3-exoplayer:1.5.0")
+     implementation("androidx.media3:media3-exoplayer-hls:1.5.0")
+     implementation("androidx.media3:media3-exoplayer-dash:1.5.0")
  }

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -11,7 +11,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.platform.PlatformView
 import me.albemala.native_video_player.platform_interface.*
@@ -71,8 +71,8 @@ class NativeVideoPlayerViewController(
         when (videoSource.type) {
             VideoSourceType.Asset, VideoSourceType.File -> player.setMediaItem(mediaItem)
             VideoSourceType.Network -> {
-                val dataSource = DefaultHttpDataSource.Factory().setDefaultRequestProperties(videoSource.headers)
-                val mediaSource = ProgressiveMediaSource.Factory(dataSource).createMediaSource(mediaItem)
+                val dataSource = DefaultHttpDataSource.Factory().setAllowCrossProtocolRedirects(true).setDefaultRequestProperties(videoSource.headers)
+                val mediaSource = DefaultMediaSourceFactory(dataSource).createMediaSource(mediaItem)
                 player.setMediaSource(mediaSource)
             }
         }

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -11,7 +11,9 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.dash.DashMediaSource
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.platform.PlatformView
 import me.albemala.native_video_player.platform_interface.*
@@ -71,8 +73,18 @@ class NativeVideoPlayerViewController(
         when (videoSource.type) {
             VideoSourceType.Asset, VideoSourceType.File -> player.setMediaItem(mediaItem)
             VideoSourceType.Network -> {
-                val dataSource = DefaultHttpDataSource.Factory().setAllowCrossProtocolRedirects(true).setDefaultRequestProperties(videoSource.headers)
-                val mediaSource = DefaultMediaSourceFactory(dataSource).createMediaSource(mediaItem)
+                val dataSource = DefaultHttpDataSource.Factory().setDefaultRequestProperties(videoSource.headers)
+                val mediaSource = ProgressiveMediaSource.Factory(dataSource).createMediaSource(mediaItem)
+                player.setMediaSource(mediaSource)
+            }
+            VideoSourceType.HLS -> {
+                val dataSource = DefaultHttpDataSource.Factory().setDefaultRequestProperties(videoSource.headers)
+                val mediaSource = HlsMediaSource.Factory(dataSource).createMediaSource(mediaItem)
+                player.setMediaSource(mediaSource)
+            }
+            VideoSourceType.DASH -> {
+                val dataSource = DefaultHttpDataSource.Factory().setDefaultRequestProperties(videoSource.headers)
+                val mediaSource = DashMediaSource.Factory(dataSource).createMediaSource(mediaItem)
                 player.setMediaSource(mediaSource)
             }
         }

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoSourceType.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoSourceType.kt
@@ -3,5 +3,7 @@ package me.albemala.native_video_player.platform_interface
 enum class VideoSourceType(val value: String) {
     Asset("asset"),
     File("file"),
+    HLS("hls"),
+    DASH("dash"),
     Network("network");
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   fake_async:
     dependency: transitive
     description:
@@ -79,18 +79,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -206,7 +206,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -235,10 +235,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -251,10 +251,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -275,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/lib/src/video_source.g.dart
+++ b/lib/src/video_source.g.dart
@@ -23,4 +23,6 @@ const _$VideoSourceTypeEnumMap = {
   VideoSourceType.asset: 'asset',
   VideoSourceType.file: 'file',
   VideoSourceType.network: 'network',
+  VideoSourceType.hls: 'hls',
+  VideoSourceType.dash: 'dash',
 };

--- a/lib/src/video_source_type.dart
+++ b/lib/src/video_source_type.dart
@@ -5,4 +5,6 @@ enum VideoSourceType {
   asset,
   file,
   network,
+  hls,
+  dash
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_video_player
 description: A Flutter widget to play videos on iOS and Android using a native implementation.
-version: 1.3.1
+version: 1.3.2
 repository: https://github.com/albemala/native_video_player
 
 environment:


### PR DESCRIPTION
Hello.
It would be cool to play HLS/DASH streams (instead of transcoded videos) using Immich app & Immich server fork.

It's not breaking usual video playback that Immich currently uses.