### PR TITLE
fix: Don't crash on Android if data source throws Exception

### DIFF
--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -134,7 +134,7 @@ class NativeVideoPlayerViewController(
         if (error.cause == null) {
             api.onError(Error("Unknown playback error occurred"))
         } else {
-            api.onError(error.cause as Error)
+            api.onError(error.cause as Throwable)
         }
     }
 }

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
@@ -48,7 +48,7 @@ class NativeVideoPlayerApi(
         channel.invokeMethod("onPlaybackEnded", null)
     }
 
-    fun onError(error: Error) {
+    fun onError(error: Throwable) {
         channel.invokeMethod("onError", error.message)
     }
 


### PR DESCRIPTION
See https://github.com/immich-app/immich/issues/15230#issuecomment-2584312782. So far, only `java.lang.Error` was caught, but `HttpDataSource.InvalidResponseCodeException` is a `java.lang.Exception`.