### PR TITLE
fix: defer enabling playback mode until a video is actually played

### DIFF
--- a/ios/Classes/NativeVideoPlayerViewController.swift
+++ b/ios/Classes/NativeVideoPlayerViewController.swift
@@ -23,6 +23,16 @@ public class NativeVideoPlayerViewController: NSObject, FlutterPlatformView {
 
         api.delegate = self
         player.addObserver(self, forKeyPath: "status", context: nil)
+        
+        // Play audio even when the device is in silent mode
+        do {
+            try AVAudioSession.sharedInstance().setCategory(
+                .playback,
+                mode: .default)
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            print("Failed to set playback audio session. Error: \(error)")
+        }
     }
 
     deinit {


### PR DESCRIPTION
### Description

- Handles the iOS playback mode handling directly inside the plugin. The upstream maintainer also seems to be doing it this way in the next version of the library - [Ref](https://github.com/albemala/native_video_player/blob/c7e0b1b582319d3f51ff9a26c795cd490fcc7f67/ios/Classes/NativeVideoPlayerViewController.swift#L31-L41)