### PR TITLE
feat: millisecond precision

### DIFF
--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -81,11 +81,11 @@ class NativeVideoPlayerViewController(
 
     override fun getVideoInfo(): VideoInfo {
         val videoSize = player.videoSize
-        return VideoInfo(videoSize.height, videoSize.width, player.duration.toInt() / 1000)
+        return VideoInfo(videoSize.height, videoSize.width, player.duration)
     }
 
-    override fun getPlaybackPosition(): Int {
-        return player.currentPosition.toInt() / 1000
+    override fun getPlaybackPosition(): Long {
+        return player.currentPosition
     }
 
     override fun play() {
@@ -104,8 +104,8 @@ class NativeVideoPlayerViewController(
         return player.isPlaying
     }
 
-    override fun seekTo(position: Int) {
-        player.seekTo(position.toLong() * 1000)
+    override fun seekTo(position: Long) {
+        player.seekTo(position)
     }
 
     override fun setPlaybackSpeed(speed: Double) {

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -155,7 +155,7 @@ class NativeVideoPlayerViewController(
                     lastPosition = position
                     api.onPlaybackPositionChanged(position)
                 }
-                positionUpdateHandler.postDelayed(this, 1 / 120)
+                positionUpdateHandler.postDelayed(this, 8L)
             }
         }
         positionUpdateHandler.post(positionUpdateRunnable!!)

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -1,6 +1,8 @@
 package me.albemala.native_video_player
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.view.SurfaceView
 import android.view.View
 import android.widget.RelativeLayout
@@ -28,6 +30,10 @@ class NativeVideoPlayerViewController(
     private val player: ExoPlayer
     private val view: SurfaceView
     private val relativeLayout: RelativeLayout
+
+    private val positionUpdateHandler = Handler(Looper.getMainLooper())
+    private var positionUpdateRunnable: Runnable? = null
+    private var lastPosition = -1L
 
     init {
         api.delegate = this
@@ -60,8 +66,9 @@ class NativeVideoPlayerViewController(
     }
 
     override fun dispose() {
-        api.dispose()
         player.removeListener(this)
+        stopPositionUpdates()
+        api.dispose()
         player.release()
     }
 
@@ -81,7 +88,7 @@ class NativeVideoPlayerViewController(
 
     override fun getVideoInfo(): VideoInfo {
         val videoSize = player.videoSize
-        return VideoInfo(videoSize.height, videoSize.width, player.duration)
+        return VideoInfo(videoSize.height.toLong(), videoSize.width.toLong(), player.duration)
     }
 
     override fun getPlaybackPosition(): Long {
@@ -122,7 +129,8 @@ class NativeVideoPlayerViewController(
 
     override fun onPlaybackStateChanged(@Player.State state: Int) {
         if (state == Player.STATE_READY) {
-            return api.onPlaybackReady()
+            api.onPlaybackReady()
+            startPositionUpdates()
         }
 
         if (state == Player.STATE_ENDED) {
@@ -135,6 +143,28 @@ class NativeVideoPlayerViewController(
             api.onError(Error("Unknown playback error occurred"))
         } else {
             api.onError(error.cause as Throwable)
+        }
+    }
+
+    private fun startPositionUpdates() {
+        stopPositionUpdates()
+        positionUpdateRunnable = object : Runnable {
+            override fun run() {
+                val position = player.currentPosition
+                if (lastPosition != position) {
+                    lastPosition = position
+                    api.onPlaybackPositionChanged(position)
+                }
+                positionUpdateHandler.postDelayed(this, 1 / 120)
+            }
+        }
+        positionUpdateHandler.post(positionUpdateRunnable!!)
+    }
+
+    private fun stopPositionUpdates() {
+        positionUpdateRunnable?.let {
+            positionUpdateHandler.removeCallbacks(it)
+            positionUpdateRunnable = null
         }
     }
 }

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
@@ -12,7 +12,7 @@ interface NativeVideoPlayerApiDelegate {
     fun pause()
     fun stop()
     fun isPlaying(): Boolean
-    fun seekTo(position: Int)
+    fun seekTo(position: Long)
     fun setPlaybackSpeed(speed: Double)
     fun setVolume(volume: Double)
     fun setLoop(loop: Boolean)
@@ -46,6 +46,10 @@ class NativeVideoPlayerApi(
 
     fun onPlaybackEnded() {
         channel.invokeMethod("onPlaybackEnded", null)
+    }
+
+    fun onPlaybackPositionChanged(position: Long) {
+        channel.invokeMethod("onPlaybackPositionChanged", position)
     }
 
     fun onError(error: Throwable) {

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
@@ -7,7 +7,7 @@ import io.flutter.plugin.common.MethodChannel
 interface NativeVideoPlayerApiDelegate {
     fun loadVideoSource(videoSource: VideoSource)
     fun getVideoInfo(): VideoInfo
-    fun getPlaybackPosition(): Int
+    fun getPlaybackPosition(): Long
     fun play()
     fun pause()
     fun stop()
@@ -85,7 +85,7 @@ class NativeVideoPlayerApi(
                 result.success(playing)
             }
             "seekTo" -> {
-                val position = methodCall.arguments as? Int
+                val position = methodCall.arguments as? Long
                     ?: return result.error(invalidArgumentsErrorCode, invalidArgumentsErrorMessage, null)
                 delegate?.seekTo(position)
                 result.success(null)

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoInfo.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/VideoInfo.kt
@@ -1,11 +1,11 @@
 package me.albemala.native_video_player.platform_interface
 
 data class VideoInfo(
-    val height: Int,
-    val width: Int,
-    val duration: Int
+    val height: Long,
+    val width: Long,
+    val duration: Long
 ) {
-    fun toMap(): Map<String, Int> = mapOf(
+    fun toMap(): Map<String, Long> = mapOf(
         "height" to height,
         "width" to width,
         "duration" to duration

--- a/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
+++ b/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
@@ -1,12 +1,12 @@
 protocol NativeVideoPlayerApiDelegate: AnyObject {
     func loadVideoSource(videoSource: VideoSource)
     func getVideoInfo() -> VideoInfo
-    func getPlaybackPosition() -> Int
+    func getPlaybackPosition() -> Int64
     func play()
     func pause()
     func stop(completion: @escaping () -> Void)
     func isPlaying() -> Bool
-    func seekTo(position: Int, completion: @escaping () -> Void)
+    func seekTo(position: Int64, completion: @escaping () -> Void)
     func setPlaybackSpeed(speed: Double)
     func setVolume(volume: Double)
     func setLoop(loop: Bool)
@@ -81,7 +81,7 @@ class NativeVideoPlayerApi {
             let playing = delegate?.isPlaying()
             result(playing)
         case "seekTo":
-            guard let position = call.arguments as? Int else {
+            guard let position = call.arguments as? Int64 else {
                 result(invalidArgumentsFlutterError)
                 return
             }

--- a/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
+++ b/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
@@ -44,6 +44,10 @@ class NativeVideoPlayerApi {
         channel.invokeMethod("onPlaybackEnded", arguments: nil)
     }
 
+    func onPlaybackPositionChanged(position: Int64) {
+        channel.invokeMethod("onPlaybackPositionChanged", arguments: position)
+    }
+
     func onError(_ error: Error) {
         channel.invokeMethod("onError", arguments: error.localizedDescription)
     }

--- a/ios/Classes/PlatformInterface/VideoInfo.swift
+++ b/ios/Classes/PlatformInterface/VideoInfo.swift
@@ -1,7 +1,7 @@
 struct VideoInfo {
     let height: Int
     let width: Int
-    let duration: Int
+    let duration: Int64
 
     func toMap() -> [String: Any] {
         [

--- a/lib/src/platform_interface/native_video_player_api.dart
+++ b/lib/src/platform_interface/native_video_player_api.dart
@@ -6,6 +6,7 @@ class NativeVideoPlayerApi {
   final int viewId;
   final void Function() onPlaybackReady;
   final void Function() onPlaybackEnded;
+  final void Function(int) onPlaybackPositionChanged;
   final void Function(String?) onError;
   late final MethodChannel _channel;
 
@@ -13,6 +14,7 @@ class NativeVideoPlayerApi {
     required this.viewId,
     required this.onPlaybackReady,
     required this.onPlaybackEnded,
+    required this.onPlaybackPositionChanged,
     required this.onError,
   }) {
     final name = 'me.albemala.native_video_player.api.$viewId';
@@ -30,6 +32,9 @@ class NativeVideoPlayerApi {
         onPlaybackReady();
       case 'onPlaybackEnded':
         onPlaybackEnded();
+      case 'onPlaybackPositionChanged':
+        final position = call.arguments as int;
+        onPlaybackPositionChanged(position);
       case 'onError':
         // final errorCode = call.arguments['errorCode'] as int;
         // final errorMessage = call.arguments['errorMessage'] as String;

--- a/lib/src/playback_info.dart
+++ b/lib/src/playback_info.dart
@@ -6,7 +6,7 @@ class PlaybackInfo {
   /// The current playback status.
   final PlaybackStatus status;
 
-  /// The current playback position, in seconds.
+  /// The current playback position, in milliseconds.
   final int position;
 
   /// The current playback position as a value between 0 and 1.

--- a/lib/src/video_info.dart
+++ b/lib/src/video_info.dart
@@ -12,7 +12,7 @@ class VideoInfo {
   /// Width of the video frame, in pixels.
   final int width;
 
-  /// Duration of the video, in seconds.
+  /// Duration of the video, in milliseconds.
   final int duration;
 
   /// Aspect ratio of the video frame, in pixels.


### PR DESCRIPTION
This PR changes the player APIs from using seconds to milliseconds, allowing for much more precise seeking and position updates. It updates the position up to every 1/120 seconds so as to keep fluidity for high frame rate videos. Because the volume of updates is higher, it also makes optimizations to lower the amount of communication needed between the Dart and platform side. Specifically, the position is now polled on the platform side and not emitted to Dart unless the value is actually different from the last one.

Tested on a branch using these changes in the main Immich app on iOS and Android.

Based on #10, which should be merged first.