### PR TITLE
fix: use int for seeking

### DIFF
--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -111,8 +111,8 @@ class NativeVideoPlayerViewController(
         return player.isPlaying
     }
 
-    override fun seekTo(position: Long) {
-        player.seekTo(position)
+    override fun seekTo(position: Int) {
+        player.seekTo(position.toLong())
     }
 
     override fun setPlaybackSpeed(speed: Double) {

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
@@ -12,7 +12,7 @@ interface NativeVideoPlayerApiDelegate {
     fun pause()
     fun stop()
     fun isPlaying(): Boolean
-    fun seekTo(position: Long)
+    fun seekTo(position: Int)
     fun setPlaybackSpeed(speed: Double)
     fun setVolume(volume: Double)
     fun setLoop(loop: Boolean)
@@ -89,7 +89,7 @@ class NativeVideoPlayerApi(
                 result.success(playing)
             }
             "seekTo" -> {
-                val position = methodCall.arguments as? Long
+                val position = methodCall.arguments as? Int
                     ?: return result.error(invalidArgumentsErrorCode, invalidArgumentsErrorMessage, null)
                 delegate?.seekTo(position)
                 result.success(null)


### PR DESCRIPTION
Apparently the method channel interprets smaller integers as Integer type on the platform side, making the cast here fail. The quick fix is to expect integers, which are enough to represent up to ~25 days.

The commit in the app's pubspec.yaml file should be updated after this is merged.