### PR TITLE
feat: handle aspect ratio

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.13.0")
+        classpath("com.android.tools.build:gradle:8.13.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -51,5 +51,6 @@ android {
 
  dependencies {
      implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-     implementation("androidx.media3:media3-exoplayer:1.8.0")
+     implementation("androidx.media3:media3-exoplayer:1.9.2")
+     implementation("androidx.media3:media3-ui:1.9.2")
  }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -4,20 +4,24 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.view.SurfaceView
+import android.view.Gravity
 import android.view.View
-import android.widget.RelativeLayout
+import android.widget.FrameLayout
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.ui.AspectRatioFrameLayout
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.platform.PlatformView
 import me.albemala.native_video_player.platform_interface.*
 
+@OptIn(UnstableApi::class)
 class NativeVideoPlayerViewController(
     messenger: BinaryMessenger,
     viewId: Int,
@@ -29,7 +33,8 @@ class NativeVideoPlayerViewController(
 
     private val player: ExoPlayer
     private val view: SurfaceView
-    private val relativeLayout: RelativeLayout
+    private val container: FrameLayout
+    private val aspectRatioLayout: AspectRatioFrameLayout
 
     private val positionUpdateHandler = Handler(Looper.getMainLooper())
     private var positionUpdateRunnable: Runnable? = null
@@ -42,27 +47,31 @@ class NativeVideoPlayerViewController(
 
         view = SurfaceView(context)
         view.setBackgroundColor(0)
-        val layoutParams = RelativeLayout.LayoutParams(
-            RelativeLayout.LayoutParams.MATCH_PARENT,
-            RelativeLayout.LayoutParams.MATCH_PARENT
+        view.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
         )
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP)
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-        view.layoutParams = layoutParams
         player.setVideoSurfaceView(view)
 
-        relativeLayout = RelativeLayout(context)
-        relativeLayout.layoutParams = RelativeLayout.LayoutParams(
-            RelativeLayout.LayoutParams.MATCH_PARENT,
-            RelativeLayout.LayoutParams.MATCH_PARENT
+        aspectRatioLayout = AspectRatioFrameLayout(context)
+        aspectRatioLayout.visibility = View.INVISIBLE
+        aspectRatioLayout.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            Gravity.CENTER
         )
-        relativeLayout.addView(view)
+        aspectRatioLayout.addView(view)
+
+        container = FrameLayout(context)
+        container.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
+        )
+        container.addView(aspectRatioLayout)
     }
 
     override fun getView(): View {
-        return relativeLayout
+        return container
     }
 
     override fun dispose() {
@@ -72,7 +81,6 @@ class NativeVideoPlayerViewController(
         player.release()
     }
 
-    @OptIn(UnstableApi::class)
     override fun loadVideoSource(videoSource: VideoSource) {
         val mediaItem = MediaItem.fromUri(videoSource.path)
         when (videoSource.type) {
@@ -135,6 +143,16 @@ class NativeVideoPlayerViewController(
 
         if (state == Player.STATE_ENDED) {
             return api.onPlaybackEnded()
+        }
+    }
+
+    override fun onVideoSizeChanged(videoSize: VideoSize) {
+        if (videoSize.height <= 0) return
+        aspectRatioLayout.setAspectRatio(
+            (videoSize.width * videoSize.pixelWidthHeightRatio) / videoSize.height
+        )
+        if (aspectRatioLayout.visibility != View.VISIBLE) {
+            aspectRatioLayout.post { aspectRatioLayout.visibility = View.VISIBLE }
         }
     }
 

--- a/ios/Classes/NativeVideoPlayerView.swift
+++ b/ios/Classes/NativeVideoPlayerView.swift
@@ -17,7 +17,7 @@ class NativeVideoPlayerView: UIView {
 
         backgroundColor = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
 
-        playerLayer.videoGravity = .resize
+        playerLayer.videoGravity = .resizeAspect
         layer.addSublayer(playerLayer)
     }
 


### PR DESCRIPTION
This makes stretching impossible since it's using the real video dimensions as reported by the video player on playback.

Tested on iOS and Android with the `AspectRatio` widget removed.