### PR TITLE
feat: hls

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,4 +52,5 @@ android {
  dependencies {
      implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
      implementation("androidx.media3:media3-exoplayer:1.9.2")
+     implementation("androidx.media3:media3-exoplayer-hls:1.9.2")
  }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ android {
 
  dependencies {
      implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-     implementation("androidx.media3:media3-exoplayer:1.9.2")
-     implementation("androidx.media3:media3-exoplayer-hls:1.9.2")
+     implementation("androidx.media3:media3-exoplayer:1.10.1")
+     implementation("androidx.media3:media3-exoplayer-hls:1.10.1")
  }

--- a/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/NativeVideoPlayerViewController.kt
@@ -7,13 +7,17 @@ import android.view.SurfaceView
 import android.view.View
 import android.widget.RelativeLayout
 import androidx.annotation.OptIn
+import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.hls.HlsManifest
+import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.platform.PlatformView
@@ -36,6 +40,7 @@ class NativeVideoPlayerViewController(
     private val positionUpdateHandler = Handler(Looper.getMainLooper())
     private var positionUpdateRunnable: Runnable? = null
     private var lastPosition = -1L
+    private var lastResolvedUrl: String? = null
 
     init {
         api.delegate = this
@@ -76,13 +81,19 @@ class NativeVideoPlayerViewController(
 
     @OptIn(UnstableApi::class)
     override fun loadVideoSource(videoSource: VideoSource) {
+        lastResolvedUrl = null
         val mediaItem = MediaItem.fromUri(videoSource.path)
         when (videoSource.type) {
             VideoSourceType.Asset, VideoSourceType.File -> player.setMediaItem(mediaItem)
             VideoSourceType.Network -> {
                 val dataSource = dataSourceFactory?.invoke(videoSource.headers)
                     ?: DefaultHttpDataSource.Factory().setDefaultRequestProperties(videoSource.headers)
-                val mediaSource = ProgressiveMediaSource.Factory(dataSource).createMediaSource(mediaItem)
+                val isHls = Uri.parse(videoSource.path).path?.endsWith(".m3u8") == true
+                val mediaSource = if (isHls) {
+                    HlsMediaSource.Factory(dataSource).createMediaSource(mediaItem)
+                } else {
+                    ProgressiveMediaSource.Factory(dataSource).createMediaSource(mediaItem)
+                }
                 player.setMediaSource(mediaSource)
             }
         }
@@ -138,6 +149,16 @@ class NativeVideoPlayerViewController(
 
         if (state == Player.STATE_ENDED) {
             return api.onPlaybackEnded()
+        }
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+        val manifest = player.currentManifest as? HlsManifest ?: return
+        val url = manifest.mediaPlaylist.baseUri
+        if (url != lastResolvedUrl) {
+            lastResolvedUrl = url
+            api.onPlaybackSourceResolved(url)
         }
     }
 

--- a/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
+++ b/android/src/main/kotlin/me/albemala/native_video_player/platform_interface/NativeVideoPlayerApi.kt
@@ -52,6 +52,10 @@ class NativeVideoPlayerApi(
         channel.invokeMethod("onPlaybackPositionChanged", position)
     }
 
+    fun onPlaybackSourceResolved(url: String) {
+        channel.invokeMethod("onPlaybackSourceResolved", url)
+    }
+
     fun onError(error: Throwable) {
         channel.invokeMethod("onError", error.message)
     }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,34 +21,34 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -79,50 +79,50 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   native_video_player:
     dependency: "direct main"
     description:
@@ -134,10 +134,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: transitive
     description:
@@ -206,7 +206,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -219,18 +219,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -251,18 +251,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   very_good_analysis:
     dependency: "direct dev"
     description:
@@ -288,5 +288,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/ios/Classes/NativeVideoPlayerView.swift
+++ b/ios/Classes/NativeVideoPlayerView.swift
@@ -29,6 +29,5 @@ class NativeVideoPlayerView: UIView {
         super.layoutSubviews()
         playerLayer.frame = bounds
         playerLayer.removeAllAnimations()
-        print("[nvp-size] view.bounds=\(bounds) layer.frame=\(playerLayer.frame) screen.scale=\(UIScreen.main.scale)")
     }
 }

--- a/ios/Classes/NativeVideoPlayerView.swift
+++ b/ios/Classes/NativeVideoPlayerView.swift
@@ -29,5 +29,6 @@ class NativeVideoPlayerView: UIView {
         super.layoutSubviews()
         playerLayer.frame = bounds
         playerLayer.removeAllAnimations()
+        print("[nvp-size] view.bounds=\(bounds) layer.frame=\(playerLayer.frame) screen.scale=\(UIScreen.main.scale)")
     }
 }

--- a/ios/Classes/NativeVideoPlayerViewController.swift
+++ b/ios/Classes/NativeVideoPlayerViewController.swift
@@ -11,6 +11,7 @@ public class NativeVideoPlayerViewController: NSObject, FlutterPlatformView {
     private var playbackRegistration: PlaybackRegistration?
     private var timeObserver: Any?
     private var timeControlObserver: NSKeyValueObservation?
+    private var metricsTask: Task<Void, Never>?
 
     private func unregisterPlayback() {
         if #available(iOS 15.0, *), let registration = playbackRegistration {
@@ -47,6 +48,7 @@ public class NativeVideoPlayerViewController: NSObject, FlutterPlatformView {
     deinit {
         player.removeObserver(self, forKeyPath: "status")
         timeControlObserver?.invalidate()
+        metricsTask?.cancel()
         removeOnVideoCompletedObserver()
         removePeriodicTimeObserver()
         unregisterPlayback()
@@ -102,6 +104,9 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
         let playerItem = AVPlayerItem(asset: videoAsset)
         removeOnVideoCompletedObserver()
         player.replaceCurrentItem(with: playerItem)
+        if #available(iOS 18.0, *) {
+            observeMetrics(for: playerItem)
+        }
         addOnVideoCompletedObserver()
         timeControlObserver = addTimeControlObserver(currentItem: playerItem)
         api.onPlaybackReady()
@@ -305,5 +310,26 @@ extension NativeVideoPlayerViewController {
             player.removeTimeObserver(observer)
             timeObserver = nil
         }
+    }
+}
+
+// MARK: - AVMetrics debug logging
+
+@available(iOS 18.0, *)
+extension NativeVideoPlayerViewController {
+    /// DEBUG: subscribe to every AVMetricEvent emitted for the given item and log it.
+    func observeMetrics(for playerItem: AVPlayerItem) {
+        metricsTask?.cancel()
+        metricsTask = Task { [weak playerItem] in
+            guard let playerItem else { return }
+            for await event in playerItem.allMetrics() {
+                NativeVideoPlayerViewController.logMetricEvent(event)
+            }
+        }
+    }
+
+    private static func logMetricEvent(_ event: AVMetricEvent) {
+        let type = String(describing: Swift.type(of: event))
+        print("[AVMetrics] \(type) date=\(event.date) \(String(reflecting: event))")
     }
 }

--- a/ios/Classes/NativeVideoPlayerViewController.swift
+++ b/ios/Classes/NativeVideoPlayerViewController.swift
@@ -322,8 +322,12 @@ extension NativeVideoPlayerViewController {
         metricsTask?.cancel()
         metricsTask = Task { [weak playerItem] in
             guard let playerItem else { return }
-            for await event in playerItem.allMetrics() {
-                NativeVideoPlayerViewController.logMetricEvent(event)
+            do {
+                for try await event in playerItem.allMetrics() {
+                    NativeVideoPlayerViewController.logMetricEvent(event)
+                }
+            } catch {
+                print("[AVMetrics] stream ended with error: \(error)")
             }
         }
     }

--- a/ios/Classes/NativeVideoPlayerViewController.swift
+++ b/ios/Classes/NativeVideoPlayerViewController.swift
@@ -8,8 +8,17 @@ public class NativeVideoPlayerViewController: NSObject, FlutterPlatformView {
     private let playerView: NativeVideoPlayerView
     private var loop = false
     private var lastPosition: Int64 = -1
+    private var lastResolvedUri: String?
+    private var playbackRegistration: PlaybackRegistration?
     private var timeObserver: Any?
     private var timeControlObserver: NSKeyValueObservation?
+
+    private func unregisterPlayback() {
+        if #available(iOS 15.0, *), let registration = playbackRegistration {
+            VideoProxyServer.shared.unregisterPlayback(registration)
+        }
+        playbackRegistration = nil
+    }
 
     init(
         messenger: FlutterBinaryMessenger,
@@ -40,7 +49,9 @@ public class NativeVideoPlayerViewController: NSObject, FlutterPlatformView {
         player.removeObserver(self, forKeyPath: "status")
         timeControlObserver?.invalidate()
         removeOnVideoCompletedObserver()
+        removeAccessLogObserver()
         removePeriodicTimeObserver()
+        unregisterPlayback()
 
         player.replaceCurrentItem(with: nil)
     }
@@ -56,22 +67,38 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
         let isUrl = videoSource.type == .network
         let sourcePath = videoSource.path
         guard let uri = isUrl ? URL(string: sourcePath) : URL(fileURLWithPath: sourcePath) else { return }
+        unregisterPlayback()
 
         let videoAsset: AVAsset
         if isUrl, #available(iOS 15.0, *), let proxyURL = VideoProxyServer.shared.proxyURL(for: uri) {
+            // Per-request headers like segment hints require routing through the proxy.
+            if uri.path.hasSuffix(".m3u8") {
+                playbackRegistration = VideoProxyServer.shared.registerPlayback(playlist: uri) { [weak player] in
+                    guard let time = player?.currentTime(), time.isNumeric else { return nil }
+                    return time.seconds
+                }
+            }
             videoAsset = AVURLAsset(url: proxyURL)
         } else if isUrl {
-            var headers = HTTPCookie.requestHeaderFields(with: SwiftNativeVideoPlayerPlugin.cookieStorage?.cookies(for: uri) ?? [])
-            headers.merge(videoSource.headers) { _, new in new }
-            videoAsset = AVURLAsset(url: uri, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
+            var options: [String: Any] = [:]
+            if let cookies = SwiftNativeVideoPlayerPlugin.cookieStorage?.cookies(for: uri), !cookies.isEmpty {
+                options[AVURLAssetHTTPCookiesKey] = cookies
+            }
+            if !videoSource.headers.isEmpty {
+                options["AVURLAssetHTTPHeaderFieldsKey"] = videoSource.headers
+            }
+            videoAsset = AVURLAsset(url: uri, options: options)
         } else {
             videoAsset = AVAsset(url: uri)
         }
 
+        lastResolvedUri = nil
         let playerItem = AVPlayerItem(asset: videoAsset)
         removeOnVideoCompletedObserver()
+        removeAccessLogObserver()
         player.replaceCurrentItem(with: playerItem)
         addOnVideoCompletedObserver()
+        addAccessLogObserver()
         timeControlObserver = addTimeControlObserver(currentItem: playerItem)
         api.onPlaybackReady()
         addPeriodicTimeObserver()
@@ -95,13 +122,22 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
                 async let d = asset.load(.duration)
                 async let t = asset.loadTracks(withMediaType: .video)
 
-                let duration = try await d
-                let size = try await t.first?.load(.naturalSize) ?? .zero
+                var duration = try await d
+                var size = try await t.first?.load(.naturalSize) ?? .zero
+
+                // HLS assets report an indefinite duration and expose no tracks;
+                // fall back to the player item, which reflects the loaded playlist.
+                if !duration.isNumeric, let itemDuration = player.currentItem?.duration, itemDuration.isNumeric {
+                    duration = itemDuration
+                }
+                if size == .zero, let presentationSize = player.currentItem?.presentationSize {
+                    size = presentationSize
+                }
 
                 let info = VideoInfo(
                     height: Int(size.height),
                     width: Int(size.width),
-                    duration: Int64(duration.seconds * 1000)
+                    duration: duration.isNumeric ? Int64(duration.seconds * 1000) : 0
                 )
                 completion(info)
             } catch {
@@ -117,7 +153,7 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
 
         asset.loadValuesAsynchronously(forKeys: ["duration", "tracks"]) {
             let duration: Int64
-            if asset.statusOfValue(forKey: "duration", error: nil) == .loaded {
+            if asset.statusOfValue(forKey: "duration", error: nil) == .loaded, asset.duration.isNumeric {
                 duration = Int64(asset.duration.seconds * 1000)
             } else {
                 duration = 0
@@ -231,6 +267,33 @@ extension NativeVideoPlayerViewController {
         NotificationCenter.default.removeObserver(
             self,
             name: .AVPlayerItemDidPlayToEndTime,
+            object: player.currentItem
+        )
+    }
+
+    @objc
+    private func onAccessLogEntry(notification: NSNotification) {
+        guard let item = notification.object as? AVPlayerItem,
+              let uri = item.accessLog()?.events.last?.uri,
+              uri != self.lastResolvedUri
+        else { return }
+        self.lastResolvedUri = uri
+        self.api.onPlaybackSourceResolved(uri)
+    }
+
+    private func addAccessLogObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onAccessLogEntry(notification:)),
+            name: .AVPlayerItemNewAccessLogEntry,
+            object: player.currentItem
+        )
+    }
+
+    private func removeAccessLogObserver() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: .AVPlayerItemNewAccessLogEntry,
             object: player.currentItem
         )
     }

--- a/ios/Classes/NativeVideoPlayerViewController.swift
+++ b/ios/Classes/NativeVideoPlayerViewController.swift
@@ -78,7 +78,10 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
                         return time.seconds
                     },
                     onResolved: { [weak self] url in
-                        self?.api.onPlaybackSourceResolved(url.absoluteString)
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self, let currentItem = self.player.currentItem else { return }
+                            self.api.onPlaybackSourceResolved(url.absoluteString)
+                        }
                     }
                 )
             }

--- a/ios/Classes/NativeVideoPlayerViewController.swift
+++ b/ios/Classes/NativeVideoPlayerViewController.swift
@@ -8,7 +8,6 @@ public class NativeVideoPlayerViewController: NSObject, FlutterPlatformView {
     private let playerView: NativeVideoPlayerView
     private var loop = false
     private var lastPosition: Int64 = -1
-    private var lastResolvedUri: String?
     private var playbackRegistration: PlaybackRegistration?
     private var timeObserver: Any?
     private var timeControlObserver: NSKeyValueObservation?
@@ -49,7 +48,6 @@ public class NativeVideoPlayerViewController: NSObject, FlutterPlatformView {
         player.removeObserver(self, forKeyPath: "status")
         timeControlObserver?.invalidate()
         removeOnVideoCompletedObserver()
-        removeAccessLogObserver()
         removePeriodicTimeObserver()
         unregisterPlayback()
 
@@ -73,10 +71,16 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
         if isUrl, #available(iOS 15.0, *), let proxyURL = VideoProxyServer.shared.proxyURL(for: uri) {
             // Per-request headers like segment hints require routing through the proxy.
             if uri.path.hasSuffix(".m3u8") {
-                playbackRegistration = VideoProxyServer.shared.registerPlayback(playlist: uri) { [weak player] in
-                    guard let time = player?.currentTime(), time.isNumeric else { return nil }
-                    return time.seconds
-                }
+                playbackRegistration = VideoProxyServer.shared.registerPlayback(
+                    playlist: uri,
+                    position: { [weak player] in
+                        guard let time = player?.currentTime(), time.isNumeric else { return nil }
+                        return time.seconds
+                    },
+                    onResolved: { [weak self] url in
+                        self?.api.onPlaybackSourceResolved(url.absoluteString)
+                    }
+                )
             }
             videoAsset = AVURLAsset(url: proxyURL)
         } else if isUrl {
@@ -92,13 +96,10 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
             videoAsset = AVAsset(url: uri)
         }
 
-        lastResolvedUri = nil
         let playerItem = AVPlayerItem(asset: videoAsset)
         removeOnVideoCompletedObserver()
-        removeAccessLogObserver()
         player.replaceCurrentItem(with: playerItem)
         addOnVideoCompletedObserver()
-        addAccessLogObserver()
         timeControlObserver = addTimeControlObserver(currentItem: playerItem)
         api.onPlaybackReady()
         addPeriodicTimeObserver()
@@ -267,33 +268,6 @@ extension NativeVideoPlayerViewController {
         NotificationCenter.default.removeObserver(
             self,
             name: .AVPlayerItemDidPlayToEndTime,
-            object: player.currentItem
-        )
-    }
-
-    @objc
-    private func onAccessLogEntry(notification: NSNotification) {
-        guard let item = notification.object as? AVPlayerItem,
-              let uri = item.accessLog()?.events.last?.uri,
-              uri != self.lastResolvedUri
-        else { return }
-        self.lastResolvedUri = uri
-        self.api.onPlaybackSourceResolved(uri)
-    }
-
-    private func addAccessLogObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(onAccessLogEntry(notification:)),
-            name: .AVPlayerItemNewAccessLogEntry,
-            object: player.currentItem
-        )
-    }
-
-    private func removeAccessLogObserver() {
-        NotificationCenter.default.removeObserver(
-            self,
-            name: .AVPlayerItemNewAccessLogEntry,
             object: player.currentItem
         )
     }

--- a/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
+++ b/ios/Classes/PlatformInterface/NativeVideoPlayerApi.swift
@@ -48,6 +48,10 @@ class NativeVideoPlayerApi {
         channel.invokeMethod("onPlaybackPositionChanged", arguments: position)
     }
 
+    func onPlaybackSourceResolved(_ url: String) {
+        channel.invokeMethod("onPlaybackSourceResolved", arguments: url)
+    }
+
     func onError(_ error: Error) {
         channel.invokeMethod("onError", arguments: error.localizedDescription)
     }

--- a/ios/Classes/VideoProxyServer.swift
+++ b/ios/Classes/VideoProxyServer.swift
@@ -2,10 +2,86 @@ import Foundation
 import Network
 import UIKit
 
+extension RandomAccessCollection where Element: Comparable, Index == Int {
+    func firstIndex(greaterThan key: Element) -> Index? {
+        var lowerBound = startIndex
+        var upperBound = endIndex
+        while lowerBound < upperBound {
+            let midIndex = lowerBound + (upperBound - lowerBound) / 2
+            if self[midIndex] > key {
+                upperBound = midIndex
+            } else {
+                lowerBound = midIndex + 1
+            }
+        }
+        return lowerBound < endIndex ? lowerBound : nil
+    }
+}
+
+/// A proxied HLS playback: its position provider plus the segment timelines parsed
+/// from its media playlists, keyed by variant directory. Doubles as the
+/// registration's ownership token.
+final class PlaybackRegistration {
+    fileprivate let key: String
+    fileprivate let position: () -> TimeInterval?
+    fileprivate var timelines: [String: [Double]] = [:]
+
+    fileprivate init(key: String, position: @escaping () -> TimeInterval?) {
+        self.key = key
+        self.position = position
+    }
+}
+
 @available(iOS 15.0, *)
 public final class VideoProxyServer: @unchecked Sendable {
     public static let shared = VideoProxyServer()
+    /// Session for upstream requests. Must use a serial delegate queue as per-request relay state is confined to it.
     public var session: URLSession?
+
+    /// Keyed by the registered playlist's directory; sub-requests resolve by longest prefix. Only accessed on `queue`.
+    private var registrations: [String: PlaybackRegistration] = [:]
+
+    func registerPlayback(playlist url: URL, position: @escaping () -> TimeInterval?) -> PlaybackRegistration {
+        let registration = PlaybackRegistration(key: url.deletingLastPathComponent().path, position: position)
+        queue.async { self.registrations[registration.key] = registration }
+        return registration
+    }
+
+    func unregisterPlayback(_ registration: PlaybackRegistration) {
+        queue.async {
+            if self.registrations[registration.key] === registration {
+                self.registrations.removeValue(forKey: registration.key)
+            }
+        }
+    }
+
+    /// Longest-prefix match of a sub-request path to its playback. Only call on `queue`.
+    fileprivate func registration(forPath path: String) -> PlaybackRegistration? {
+        var best: (key: String, registration: PlaybackRegistration)?
+        for (key, registration) in registrations where path.hasPrefix(key) {
+            if best == nil || key.count > best!.key.count {
+                best = (key, registration)
+            }
+        }
+        return best?.registration
+    }
+
+    fileprivate func storeTimeline(_ segmentEnds: [Double], forPlaylist url: URL) {
+        let playlistDir = url.deletingLastPathComponent().path
+        queue.async {
+            self.registration(forPath: playlistDir)?.timelines[playlistDir] = segmentEnds
+        }
+    }
+
+    /// The segment containing the playback position, per the timeline of the media. Only call on `queue`.
+    fileprivate func segmentHint(for url: URL) -> Int? {
+        guard let registration = registration(forPath: url.path),
+              let position = registration.position(),
+              let ends = registration.timelines[url.deletingLastPathComponent().path], !ends.isEmpty
+        else { return nil }
+        if position <= 0 { return 0 }
+        return ends.firstIndex(greaterThan: position) ?? ends.count - 1
+    }
 
     private var listener: NWListener?
     private let queue = DispatchQueue(label: "video.proxy", qos: .userInitiated)
@@ -46,7 +122,9 @@ public final class VideoProxyServer: @unchecked Sendable {
         listener = nil
 
         let port = port > 0 ? NWEndpoint.Port(rawValue: port) ?? .any : .any
-        let nwListener = try NWListener(using: .tcp, on: port)
+        let parameters = NWParameters.tcp
+        parameters.requiredInterfaceType = .loopback
+        let nwListener = try NWListener(using: parameters, on: port)
         let semaphore = DispatchSemaphore(value: 0)
         var startError: Error?
         nwListener.stateUpdateHandler = { [weak self, weak nwListener] state in
@@ -94,8 +172,11 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
     private var buffer = Data()
     private var currentTask: URLSessionDataTask?
     private var headersSent = false
+    private var captureBuffer: Data?
     private static let headerEnd = Data("\r\n\r\n".utf8)
     private static let skipHeaders: Set<String> = ["host", "connection", "proxy-connection", "keep-alive"]
+    private static let extinfTagLength = 8
+    private static let extinfTag: UInt64 = Array("#EXTINF:".utf8).withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
 
     init(connection: NWConnection, server: VideoProxyServer, queue: DispatchQueue) {
         self.connection = connection
@@ -165,6 +246,15 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
             guard !Self.skipHeaders.contains(key.lowercased()) else { continue }
             request.setValue(parts[1].trimmingCharacters(in: .whitespaces), forHTTPHeaderField: key)
         }
+        if url.lastPathComponent == "init.mp4", let segment = server?.segmentHint(for: url) {
+            request.setValue(String(segment), forHTTPHeaderField: "x-immich-hls-msn")
+        } else if url.path.hasSuffix(".m3u8"), let registration = server?.registration(forPath: url.path) {
+            if let position = registration.position(), position > 0 {
+                request.setValue(String(position), forHTTPHeaderField: "x-immich-hls-pos")
+            }
+            // Force identity so the captured and parsed bytes are never content-encoded.
+            request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+        }
         return request
     }
 
@@ -188,15 +278,27 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
         }
         head.append(contentsOf: "\r\n".utf8)
         headersSent = true
+        // Capture playlists to parse timelines
+        if http.statusCode == 200, dataTask.originalRequest?.url?.path.hasSuffix(".m3u8") == true {
+            captureBuffer = Data()
+        }
         connection.send(content: head, completion: .contentProcessed { _ in })
         completionHandler(.allow)
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        captureBuffer?.append(data)
         connection.send(content: data, completion: .contentProcessed { _ in })
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let captured = captureBuffer, error == nil, let url = task.originalRequest?.url {
+            let segmentEnds = Self.parseSegmentEnds(captured)
+            if !segmentEnds.isEmpty {
+                server?.storeTimeline(segmentEnds, forPlaylist: url)
+            }
+        }
+        captureBuffer = nil
         if let error = error {
             if (error as NSError).code == NSURLErrorCancelled { return }
             if !headersSent { return sendError(502) }
@@ -204,6 +306,43 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
         }
         currentTask = nil
         self.readRequest()
+    }
+
+    /// Cumulative segment end times from `#EXTINF:` lines.
+    private static func parseSegmentEnds(_ data: Data) -> [Double] {
+        var ends: [Double] = []
+        ends.reserveCapacity(data.count / 24)
+        var cumulative = 0.0
+        data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            guard let base = bytes.baseAddress else { return } // empty Data
+            var i = 0
+            while i < bytes.count {
+                if isExtinfLine(bytes, at: i), let duration = parseDuration(bytes, at: i + extinfTagLength) {
+                    cumulative += duration
+                    ends.append(cumulative)
+                }
+                // Skip to the next line
+                guard let newline = memchr(base + i, Int32(UInt8(ascii: "\n")), bytes.count - i) else { break }
+                i = UnsafeRawPointer(newline) - base + 1
+            }
+        }
+        return ends
+    }
+
+    private static func isExtinfLine(_ bytes: UnsafeRawBufferPointer, at i: Int) -> Bool {
+        i + extinfTagLength <= bytes.count && bytes.loadUnaligned(fromByteOffset: i, as: UInt64.self) == extinfTag
+    }
+
+    /// Duration between `i` and the next `,`/line end.
+    private static func parseDuration(_ bytes: UnsafeRawBufferPointer, at i: Int) -> Double? {
+        var j = i
+        while j < bytes.count, bytes[j] != UInt8(ascii: ","), bytes[j] != UInt8(ascii: "\n"), bytes[j] != UInt8(ascii: "\r") {
+            j += 1
+        }
+        guard let value = Double(String(decoding: bytes[i..<j], as: UTF8.self)), value.isFinite, value >= 0 else {
+            return nil
+        }
+        return value
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,

--- a/ios/Classes/VideoProxyServer.swift
+++ b/ios/Classes/VideoProxyServer.swift
@@ -336,7 +336,7 @@ private final class ProxyConnection: NSObject {
         if url.lastPathComponent == "init.mp4", let segment = server?.segmentHint(for: url) {
             request.setValue(String(segment), forHTTPHeaderField: "x-immich-hls-msn")
         } else if url.path.hasSuffix(".m3u8"), let registration = server?.registration(forPath: url.path) {
-            if let position = registration.position(), position > 0 {
+            if let position = registration.position(), position >= 0 {
                 request.setValue(String(position), forHTTPHeaderField: "x-immich-hls-pos")
             }
             // Force identity so the captured and parsed bytes are never content-encoded.

--- a/ios/Classes/VideoProxyServer.swift
+++ b/ios/Classes/VideoProxyServer.swift
@@ -39,8 +39,7 @@ final class PlaybackRegistration {
 @available(iOS 15.0, *)
 public final class VideoProxyServer: @unchecked Sendable {
     public static let shared = VideoProxyServer()
-    /// Session for upstream requests. Relay state is confined to `queue`; delegate callbacks
-    /// are hopped onto it, so the session's own delegate queue is not relied upon for ordering.
+    /// Session for upstream requests. Must use a serial delegate queue as per-request relay state is confined to it.
     public var session: URLSession?
 
     /// Keyed by the registered playlist's directory; sub-requests resolve by longest prefix. Only accessed on `queue`.
@@ -106,15 +105,6 @@ public final class VideoProxyServer: @unchecked Sendable {
     private var port: UInt16 = 0
     private var activeConnections = Set<ProxyConnection>()
 
-    /// In-flight upstream requests, keyed by request identity. Lets a client that reconnects
-    /// (e.g. AVPlayer giving up on a slow-to-ramp transcode) reattach to the still-running
-    /// request and stream from it, rather than restarting the transcode from scratch.
-    /// Only accessed on `queue`.
-    private var inflight: [String: UpstreamRequest] = [:]
-    /// How long an upstream request is kept alive with no attached client, so an imminent
-    /// reconnect can reattach (or be served from the just-completed buffer) before we give up.
-    fileprivate static let upstreamGraceTTL: TimeInterval = 5.0
-
     private init() {
         NotificationCenter.default.addObserver(
             self,
@@ -175,39 +165,6 @@ public final class VideoProxyServer: @unchecked Sendable {
 
     fileprivate func remove(_ conn: ProxyConnection) { activeConnections.remove(conn) }
 
-    /// Identity of a request for reattach matching: method + URL + byte range. Dynamic
-    /// playback hints (position/segment) are intentionally excluded so a reconnect for the
-    /// same resource reuses the in-flight request.
-    fileprivate static func requestKey(_ request: URLRequest) -> String {
-        let method = request.httpMethod ?? "GET"
-        let url = request.url?.absoluteString ?? ""
-        let range = request.value(forHTTPHeaderField: "Range") ?? ""
-        return "\(method)\u{0}\(url)\u{0}\(range)"
-    }
-
-    /// Attaches a client to an upstream request, reusing an in-flight/just-completed one for the
-    /// same key when possible, otherwise starting a fresh request. Must run on `queue`.
-    fileprivate func attach(_ connection: ProxyConnection, request: URLRequest, key: String, isPlaylist: Bool) {
-        if let existing = inflight[key], existing.canAttach {
-            existing.attach(connection)
-            return
-        }
-        guard let session = session else { return connection.deliverFailed() }
-        let upstream = UpstreamRequest(
-            key: key, request: request, isPlaylist: isPlaylist,
-            server: self, session: session, queue: queue
-        )
-        inflight[key] = upstream
-        upstream.attach(connection)
-        upstream.start()
-    }
-
-    /// Drops an upstream from the in-flight map, but only if it still owns the slot (a newer
-    /// request for the same key may have replaced it). Must run on `queue`.
-    fileprivate func removeUpstream(_ upstream: UpstreamRequest, forKey key: String) {
-        if inflight[key] === upstream { inflight.removeValue(forKey: key) }
-    }
-
     /// Reconstructs the original URL from a proxy request target (e.g. `/https/host:port/path?q=1`).
     fileprivate func originalURL(fromRequestTarget target: String) -> URL? {
         let pathQuery = target.split(separator: "?", maxSplits: 1)
@@ -225,16 +182,18 @@ public final class VideoProxyServer: @unchecked Sendable {
 }
 
 @available(iOS 15.0, *)
-private final class ProxyConnection: NSObject {
+private final class ProxyConnection: NSObject, URLSessionDataDelegate {
     let connection: NWConnection
     private weak var server: VideoProxyServer?
     private let queue: DispatchQueue
     private var buffer = Data()
-    /// The upstream request this connection is currently streaming from, if any.
-    private var upstream: UpstreamRequest?
+    private var currentTask: URLSessionDataTask?
     private var headersSent = false
+    private var captureBuffer: Data?
     private static let headerEnd = Data("\r\n\r\n".utf8)
     private static let skipHeaders: Set<String> = ["host", "connection", "proxy-connection", "keep-alive"]
+    private static let extinfTagLength = 8
+    private static let extinfTag: UInt64 = Array("#EXTINF:".utf8).withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
 
     init(connection: NWConnection, server: VideoProxyServer, queue: DispatchQueue) {
         self.connection = connection
@@ -254,10 +213,8 @@ private final class ProxyConnection: NSObject {
     }
 
     private func cleanup() {
-        // Detach from the upstream but leave it running: a reconnect for the same resource can
-        // reattach to it instead of restarting the (real-time transcoded) request from scratch.
-        upstream?.detach(self)
-        upstream = nil
+        currentTask?.cancel()
+        currentTask = nil
         server?.remove(self)
     }
 
@@ -277,40 +234,13 @@ private final class ProxyConnection: NSObject {
     }
 
     private func forwardRequest() {
-        guard let server = server else { return sendError(502) }
+        guard let session = server?.session else { return sendError(502) }
         guard let request = parseRequest() else { return sendError(400) }
+        let task = session.dataTask(with: request)
+        task.delegate = self
+        currentTask = task
         headersSent = false
-        let key = VideoProxyServer.requestKey(request)
-        let isPlaylist = request.url?.path.hasSuffix(".m3u8") ?? false
-        server.attach(self, request: request, key: key, isPlaylist: isPlaylist)
-    }
-
-    // MARK: Delivery from the attached upstream (all invoked on `queue`)
-
-    /// Binds this connection to an upstream so disconnects can orphan it for reattach.
-    fileprivate func bindUpstream(_ upstream: UpstreamRequest) {
-        self.upstream = upstream
-    }
-
-    fileprivate func deliverHead(_ head: Data) {
-        headersSent = true
-        connection.send(content: head, completion: .contentProcessed { _ in })
-    }
-
-    fileprivate func deliverBody(_ data: Data) {
-        connection.send(content: data, completion: .contentProcessed { _ in })
-    }
-
-    /// Upstream finished successfully: detach and wait for the next request (keep-alive).
-    fileprivate func deliverFinished() {
-        upstream = nil
-        readRequest()
-    }
-
-    /// Upstream failed: surface a 502 if nothing was sent yet, otherwise drop the connection.
-    fileprivate func deliverFailed() {
-        upstream = nil
-        if !headersSent { sendError(502) } else { connection.cancel() }
+        task.resume()
     }
 
     private func parseRequest() -> URLRequest? {
@@ -353,175 +283,46 @@ private final class ProxyConnection: NSObject {
             self?.connection.cancel()
         })
     }
-}
-
-/// A single upstream request whose lifetime is decoupled from the client connection that
-/// triggered it. If the client disconnects (e.g. AVPlayer giving up on a slow transcode ramp-up),
-/// the request keeps running and buffering; a reconnecting client for the same resource reattaches
-/// and is replayed the buffered prefix before streaming live, so the transcode runs only once.
-/// All state is confined to `queue`; URLSession delegate callbacks are hopped onto it.
-@available(iOS 15.0, *)
-private final class UpstreamRequest: NSObject, URLSessionDataDelegate {
-    private let key: String
-    private let request: URLRequest
-    private let isPlaylist: Bool
-    private weak var server: VideoProxyServer?
-    private let session: URLSession
-    private let queue: DispatchQueue
-
-    private var task: URLSessionDataTask?
-    /// The client currently streaming from this request, if any.
-    private weak var client: ProxyConnection?
-    /// Serialized HTTP response head, once the upstream responds.
-    private var responseHead: Data?
-    /// All body bytes received so far, for replaying to a (re)attaching client.
-    private var body = Data()
-    private var finished = false
-    private var failed = false
-    private var evictWorkItem: DispatchWorkItem?
-
-    private static let extinfTagLength = 8
-    private static let extinfTag: UInt64 = Array("#EXTINF:".utf8).withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
-
-    /// Reusable only while no client is attached and the request hasn't failed.
-    var canAttach: Bool { client == nil && !failed }
-
-    init(
-        key: String, request: URLRequest, isPlaylist: Bool,
-        server: VideoProxyServer, session: URLSession, queue: DispatchQueue
-    ) {
-        self.key = key
-        self.request = request
-        self.isPlaylist = isPlaylist
-        self.server = server
-        self.session = session
-        self.queue = queue
-    }
-
-    func start() {
-        let task = session.dataTask(with: request)
-        task.delegate = self
-        self.task = task
-        task.resume()
-    }
-
-    /// Attaches a client, replaying whatever has been buffered so far. Must run on `queue`.
-    func attach(_ connection: ProxyConnection) {
-        cancelEviction()
-        client = connection
-        connection.bindUpstream(self)
-        if let head = responseHead {
-            connection.deliverHead(head)
-            if !body.isEmpty { connection.deliverBody(body) }
-        }
-        if finished {
-            connection.deliverFinished()
-            client = nil
-            scheduleEviction()
-        } else if failed {
-            connection.deliverFailed()
-            client = nil
-            scheduleEviction()
-        }
-    }
-
-    /// Detaches a disconnecting client but keeps the request alive briefly for a reconnect.
-    /// Must run on `queue`.
-    func detach(_ connection: ProxyConnection) {
-        guard client === connection else { return }
-        client = nil
-        scheduleEviction()
-    }
-
-    private func scheduleEviction() {
-        cancelEviction()
-        let work = DispatchWorkItem { [weak self] in self?.evict() }
-        evictWorkItem = work
-        queue.asyncAfter(deadline: .now() + VideoProxyServer.upstreamGraceTTL, execute: work)
-    }
-
-    private func cancelEviction() {
-        evictWorkItem?.cancel()
-        evictWorkItem = nil
-    }
-
-    private func evict() {
-        guard client == nil else { return } // a client reattached in the meantime
-        task?.cancel()
-        task = nil
-        server?.removeUpstream(self, forKey: key)
-    }
-
-    // MARK: URLSessionDataDelegate — callbacks hop onto `queue`
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
                     didReceive response: URLResponse,
                     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        guard let http = response as? HTTPURLResponse else {
-            completionHandler(.cancel)
-            queue.async { [weak self] in self?.handleFailure() }
-            return
-        }
+        guard let http = response as? HTTPURLResponse else { return completionHandler(.cancel) }
         var head = Data(capacity: 1024)
         head.append(contentsOf: "HTTP/1.1 \(http.statusCode) \(HTTPURLResponse.localizedString(forStatusCode: http.statusCode))\r\n".utf8)
         for (key, value) in http.allHeaderFields {
             head.append(contentsOf: "\(key): \(value)\r\n".utf8)
         }
         head.append(contentsOf: "\r\n".utf8)
-        completionHandler(.allow)
-        queue.async { [weak self] in
-            guard let self = self else { return }
-            self.responseHead = head
-            self.client?.deliverHead(head)
+        headersSent = true
+        // Capture playlists to parse timelines
+        if http.statusCode == 200, dataTask.originalRequest?.url?.path.hasSuffix(".m3u8") == true {
+            captureBuffer = Data()
         }
+        connection.send(content: head, completion: .contentProcessed { _ in })
+        completionHandler(.allow)
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        queue.async { [weak self] in
-            guard let self = self else { return }
-            self.body.append(data)
-            self.client?.deliverBody(data)
-        }
+        captureBuffer?.append(data)
+        connection.send(content: data, completion: .contentProcessed { _ in })
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        queue.async { [weak self] in
-            guard let self = self else { return }
-            if let error = error {
-                // Cancellation is our own eviction tearing the task down; nothing to deliver.
-                if (error as NSError).code == NSURLErrorCancelled { self.task = nil; return }
-                return self.handleFailure()
+        if let captured = captureBuffer, error == nil, let url = task.originalRequest?.url {
+            let segmentEnds = Self.parseSegmentEnds(captured)
+            if !segmentEnds.isEmpty {
+                server?.storeTimeline(segmentEnds, forPlaylist: url)
             }
-            if self.isPlaylist {
-                let segmentEnds = UpstreamRequest.parseSegmentEnds(self.body)
-                if !segmentEnds.isEmpty, let url = self.request.url {
-                    self.server?.storeTimeline(segmentEnds, forPlaylist: url)
-                }
-            }
-            self.finished = true
-            self.task = nil
-            if let client = self.client {
-                client.deliverFinished()
-                self.client = nil
-            }
-            self.scheduleEviction()
         }
-    }
-
-    /// Marks the request failed, notifies any attached client, and schedules eviction. On `queue`.
-    private func handleFailure() {
-        guard !failed else { return }
-        failed = true
-        task = nil
-        client?.deliverFailed()
-        client = nil
-        scheduleEviction()
-    }
-
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
-                    willCacheResponse proposedResponse: CachedURLResponse,
-                    completionHandler: @escaping (CachedURLResponse?) -> Void) {
-        completionHandler(nil)
+        captureBuffer = nil
+        if let error = error {
+            if (error as NSError).code == NSURLErrorCancelled { return }
+            if !headersSent { return sendError(502) }
+            return connection.cancel()
+        }
+        currentTask = nil
+        self.readRequest()
     }
 
     /// Cumulative segment end times from `#EXTINF:` lines.
@@ -559,5 +360,11 @@ private final class UpstreamRequest: NSObject, URLSessionDataDelegate {
             return nil
         }
         return value
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
+                    willCacheResponse proposedResponse: CachedURLResponse,
+                    completionHandler: @escaping (CachedURLResponse?) -> Void) {
+        completionHandler(nil)
     }
 }

--- a/ios/Classes/VideoProxyServer.swift
+++ b/ios/Classes/VideoProxyServer.swift
@@ -24,11 +24,15 @@ extension RandomAccessCollection where Element: Comparable, Index == Int {
 final class PlaybackRegistration {
     fileprivate let key: String
     fileprivate let position: () -> TimeInterval?
+    /// Called once with the upstream URL of the first media playlist seen for this playback
+    fileprivate let onResolved: (URL) -> Void
+    fileprivate var resolved = false
     fileprivate var timelines: [String: [Double]] = [:]
 
-    fileprivate init(key: String, position: @escaping () -> TimeInterval?) {
+    fileprivate init(key: String, position: @escaping () -> TimeInterval?, onResolved: @escaping (URL) -> Void) {
         self.key = key
         self.position = position
+        self.onResolved = onResolved
     }
 }
 
@@ -41,8 +45,16 @@ public final class VideoProxyServer: @unchecked Sendable {
     /// Keyed by the registered playlist's directory; sub-requests resolve by longest prefix. Only accessed on `queue`.
     private var registrations: [String: PlaybackRegistration] = [:]
 
-    func registerPlayback(playlist url: URL, position: @escaping () -> TimeInterval?) -> PlaybackRegistration {
-        let registration = PlaybackRegistration(key: url.deletingLastPathComponent().path, position: position)
+    func registerPlayback(
+        playlist url: URL,
+        position: @escaping () -> TimeInterval?,
+        onResolved: @escaping (URL) -> Void
+    ) -> PlaybackRegistration {
+        let registration = PlaybackRegistration(
+            key: url.deletingLastPathComponent().path,
+            position: position,
+            onResolved: onResolved
+        )
         queue.async { self.registrations[registration.key] = registration }
         return registration
     }
@@ -69,7 +81,12 @@ public final class VideoProxyServer: @unchecked Sendable {
     fileprivate func storeTimeline(_ segmentEnds: [Double], forPlaylist url: URL) {
         let playlistDir = url.deletingLastPathComponent().path
         queue.async {
-            self.registration(forPath: playlistDir)?.timelines[playlistDir] = segmentEnds
+            guard let registration = self.registration(forPath: playlistDir) else { return }
+            registration.timelines[playlistDir] = segmentEnds
+            if !registration.resolved {
+                registration.resolved = true
+                registration.onResolved(url)
+            }
         }
     }
 

--- a/ios/Classes/VideoProxyServer.swift
+++ b/ios/Classes/VideoProxyServer.swift
@@ -39,7 +39,8 @@ final class PlaybackRegistration {
 @available(iOS 15.0, *)
 public final class VideoProxyServer: @unchecked Sendable {
     public static let shared = VideoProxyServer()
-    /// Session for upstream requests. Must use a serial delegate queue as per-request relay state is confined to it.
+    /// Session for upstream requests. Relay state is confined to `queue`; delegate callbacks
+    /// are hopped onto it, so the session's own delegate queue is not relied upon for ordering.
     public var session: URLSession?
 
     /// Keyed by the registered playlist's directory; sub-requests resolve by longest prefix. Only accessed on `queue`.
@@ -105,6 +106,15 @@ public final class VideoProxyServer: @unchecked Sendable {
     private var port: UInt16 = 0
     private var activeConnections = Set<ProxyConnection>()
 
+    /// In-flight upstream requests, keyed by request identity. Lets a client that reconnects
+    /// (e.g. AVPlayer giving up on a slow-to-ramp transcode) reattach to the still-running
+    /// request and stream from it, rather than restarting the transcode from scratch.
+    /// Only accessed on `queue`.
+    private var inflight: [String: UpstreamRequest] = [:]
+    /// How long an upstream request is kept alive with no attached client, so an imminent
+    /// reconnect can reattach (or be served from the just-completed buffer) before we give up.
+    fileprivate static let upstreamGraceTTL: TimeInterval = 5.0
+
     private init() {
         NotificationCenter.default.addObserver(
             self,
@@ -165,6 +175,39 @@ public final class VideoProxyServer: @unchecked Sendable {
 
     fileprivate func remove(_ conn: ProxyConnection) { activeConnections.remove(conn) }
 
+    /// Identity of a request for reattach matching: method + URL + byte range. Dynamic
+    /// playback hints (position/segment) are intentionally excluded so a reconnect for the
+    /// same resource reuses the in-flight request.
+    fileprivate static func requestKey(_ request: URLRequest) -> String {
+        let method = request.httpMethod ?? "GET"
+        let url = request.url?.absoluteString ?? ""
+        let range = request.value(forHTTPHeaderField: "Range") ?? ""
+        return "\(method)\u{0}\(url)\u{0}\(range)"
+    }
+
+    /// Attaches a client to an upstream request, reusing an in-flight/just-completed one for the
+    /// same key when possible, otherwise starting a fresh request. Must run on `queue`.
+    fileprivate func attach(_ connection: ProxyConnection, request: URLRequest, key: String, isPlaylist: Bool) {
+        if let existing = inflight[key], existing.canAttach {
+            existing.attach(connection)
+            return
+        }
+        guard let session = session else { return connection.deliverFailed() }
+        let upstream = UpstreamRequest(
+            key: key, request: request, isPlaylist: isPlaylist,
+            server: self, session: session, queue: queue
+        )
+        inflight[key] = upstream
+        upstream.attach(connection)
+        upstream.start()
+    }
+
+    /// Drops an upstream from the in-flight map, but only if it still owns the slot (a newer
+    /// request for the same key may have replaced it). Must run on `queue`.
+    fileprivate func removeUpstream(_ upstream: UpstreamRequest, forKey key: String) {
+        if inflight[key] === upstream { inflight.removeValue(forKey: key) }
+    }
+
     /// Reconstructs the original URL from a proxy request target (e.g. `/https/host:port/path?q=1`).
     fileprivate func originalURL(fromRequestTarget target: String) -> URL? {
         let pathQuery = target.split(separator: "?", maxSplits: 1)
@@ -182,18 +225,16 @@ public final class VideoProxyServer: @unchecked Sendable {
 }
 
 @available(iOS 15.0, *)
-private final class ProxyConnection: NSObject, URLSessionDataDelegate {
+private final class ProxyConnection: NSObject {
     let connection: NWConnection
     private weak var server: VideoProxyServer?
     private let queue: DispatchQueue
     private var buffer = Data()
-    private var currentTask: URLSessionDataTask?
+    /// The upstream request this connection is currently streaming from, if any.
+    private var upstream: UpstreamRequest?
     private var headersSent = false
-    private var captureBuffer: Data?
     private static let headerEnd = Data("\r\n\r\n".utf8)
     private static let skipHeaders: Set<String> = ["host", "connection", "proxy-connection", "keep-alive"]
-    private static let extinfTagLength = 8
-    private static let extinfTag: UInt64 = Array("#EXTINF:".utf8).withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
 
     init(connection: NWConnection, server: VideoProxyServer, queue: DispatchQueue) {
         self.connection = connection
@@ -213,8 +254,10 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
     }
 
     private func cleanup() {
-        currentTask?.cancel()
-        currentTask = nil
+        // Detach from the upstream but leave it running: a reconnect for the same resource can
+        // reattach to it instead of restarting the (real-time transcoded) request from scratch.
+        upstream?.detach(self)
+        upstream = nil
         server?.remove(self)
     }
 
@@ -234,13 +277,40 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
     }
 
     private func forwardRequest() {
-        guard let session = server?.session else { return sendError(502) }
+        guard let server = server else { return sendError(502) }
         guard let request = parseRequest() else { return sendError(400) }
-        let task = session.dataTask(with: request)
-        task.delegate = self
-        currentTask = task
         headersSent = false
-        task.resume()
+        let key = VideoProxyServer.requestKey(request)
+        let isPlaylist = request.url?.path.hasSuffix(".m3u8") ?? false
+        server.attach(self, request: request, key: key, isPlaylist: isPlaylist)
+    }
+
+    // MARK: Delivery from the attached upstream (all invoked on `queue`)
+
+    /// Binds this connection to an upstream so disconnects can orphan it for reattach.
+    fileprivate func bindUpstream(_ upstream: UpstreamRequest) {
+        self.upstream = upstream
+    }
+
+    fileprivate func deliverHead(_ head: Data) {
+        headersSent = true
+        connection.send(content: head, completion: .contentProcessed { _ in })
+    }
+
+    fileprivate func deliverBody(_ data: Data) {
+        connection.send(content: data, completion: .contentProcessed { _ in })
+    }
+
+    /// Upstream finished successfully: detach and wait for the next request (keep-alive).
+    fileprivate func deliverFinished() {
+        upstream = nil
+        readRequest()
+    }
+
+    /// Upstream failed: surface a 502 if nothing was sent yet, otherwise drop the connection.
+    fileprivate func deliverFailed() {
+        upstream = nil
+        if !headersSent { sendError(502) } else { connection.cancel() }
     }
 
     private func parseRequest() -> URLRequest? {
@@ -283,46 +353,175 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
             self?.connection.cancel()
         })
     }
+}
+
+/// A single upstream request whose lifetime is decoupled from the client connection that
+/// triggered it. If the client disconnects (e.g. AVPlayer giving up on a slow transcode ramp-up),
+/// the request keeps running and buffering; a reconnecting client for the same resource reattaches
+/// and is replayed the buffered prefix before streaming live, so the transcode runs only once.
+/// All state is confined to `queue`; URLSession delegate callbacks are hopped onto it.
+@available(iOS 15.0, *)
+private final class UpstreamRequest: NSObject, URLSessionDataDelegate {
+    private let key: String
+    private let request: URLRequest
+    private let isPlaylist: Bool
+    private weak var server: VideoProxyServer?
+    private let session: URLSession
+    private let queue: DispatchQueue
+
+    private var task: URLSessionDataTask?
+    /// The client currently streaming from this request, if any.
+    private weak var client: ProxyConnection?
+    /// Serialized HTTP response head, once the upstream responds.
+    private var responseHead: Data?
+    /// All body bytes received so far, for replaying to a (re)attaching client.
+    private var body = Data()
+    private var finished = false
+    private var failed = false
+    private var evictWorkItem: DispatchWorkItem?
+
+    private static let extinfTagLength = 8
+    private static let extinfTag: UInt64 = Array("#EXTINF:".utf8).withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
+
+    /// Reusable only while no client is attached and the request hasn't failed.
+    var canAttach: Bool { client == nil && !failed }
+
+    init(
+        key: String, request: URLRequest, isPlaylist: Bool,
+        server: VideoProxyServer, session: URLSession, queue: DispatchQueue
+    ) {
+        self.key = key
+        self.request = request
+        self.isPlaylist = isPlaylist
+        self.server = server
+        self.session = session
+        self.queue = queue
+    }
+
+    func start() {
+        let task = session.dataTask(with: request)
+        task.delegate = self
+        self.task = task
+        task.resume()
+    }
+
+    /// Attaches a client, replaying whatever has been buffered so far. Must run on `queue`.
+    func attach(_ connection: ProxyConnection) {
+        cancelEviction()
+        client = connection
+        connection.bindUpstream(self)
+        if let head = responseHead {
+            connection.deliverHead(head)
+            if !body.isEmpty { connection.deliverBody(body) }
+        }
+        if finished {
+            connection.deliverFinished()
+            client = nil
+            scheduleEviction()
+        } else if failed {
+            connection.deliverFailed()
+            client = nil
+            scheduleEviction()
+        }
+    }
+
+    /// Detaches a disconnecting client but keeps the request alive briefly for a reconnect.
+    /// Must run on `queue`.
+    func detach(_ connection: ProxyConnection) {
+        guard client === connection else { return }
+        client = nil
+        scheduleEviction()
+    }
+
+    private func scheduleEviction() {
+        cancelEviction()
+        let work = DispatchWorkItem { [weak self] in self?.evict() }
+        evictWorkItem = work
+        queue.asyncAfter(deadline: .now() + VideoProxyServer.upstreamGraceTTL, execute: work)
+    }
+
+    private func cancelEviction() {
+        evictWorkItem?.cancel()
+        evictWorkItem = nil
+    }
+
+    private func evict() {
+        guard client == nil else { return } // a client reattached in the meantime
+        task?.cancel()
+        task = nil
+        server?.removeUpstream(self, forKey: key)
+    }
+
+    // MARK: URLSessionDataDelegate — callbacks hop onto `queue`
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
                     didReceive response: URLResponse,
                     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        guard let http = response as? HTTPURLResponse else { return completionHandler(.cancel) }
+        guard let http = response as? HTTPURLResponse else {
+            completionHandler(.cancel)
+            queue.async { [weak self] in self?.handleFailure() }
+            return
+        }
         var head = Data(capacity: 1024)
         head.append(contentsOf: "HTTP/1.1 \(http.statusCode) \(HTTPURLResponse.localizedString(forStatusCode: http.statusCode))\r\n".utf8)
         for (key, value) in http.allHeaderFields {
             head.append(contentsOf: "\(key): \(value)\r\n".utf8)
         }
         head.append(contentsOf: "\r\n".utf8)
-        headersSent = true
-        // Capture playlists to parse timelines
-        if http.statusCode == 200, dataTask.originalRequest?.url?.path.hasSuffix(".m3u8") == true {
-            captureBuffer = Data()
-        }
-        connection.send(content: head, completion: .contentProcessed { _ in })
         completionHandler(.allow)
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            self.responseHead = head
+            self.client?.deliverHead(head)
+        }
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        captureBuffer?.append(data)
-        connection.send(content: data, completion: .contentProcessed { _ in })
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            self.body.append(data)
+            self.client?.deliverBody(data)
+        }
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        if let captured = captureBuffer, error == nil, let url = task.originalRequest?.url {
-            let segmentEnds = Self.parseSegmentEnds(captured)
-            if !segmentEnds.isEmpty {
-                server?.storeTimeline(segmentEnds, forPlaylist: url)
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            if let error = error {
+                // Cancellation is our own eviction tearing the task down; nothing to deliver.
+                if (error as NSError).code == NSURLErrorCancelled { self.task = nil; return }
+                return self.handleFailure()
             }
+            if self.isPlaylist {
+                let segmentEnds = UpstreamRequest.parseSegmentEnds(self.body)
+                if !segmentEnds.isEmpty, let url = self.request.url {
+                    self.server?.storeTimeline(segmentEnds, forPlaylist: url)
+                }
+            }
+            self.finished = true
+            self.task = nil
+            if let client = self.client {
+                client.deliverFinished()
+                self.client = nil
+            }
+            self.scheduleEviction()
         }
-        captureBuffer = nil
-        if let error = error {
-            if (error as NSError).code == NSURLErrorCancelled { return }
-            if !headersSent { return sendError(502) }
-            return connection.cancel()
-        }
-        currentTask = nil
-        self.readRequest()
+    }
+
+    /// Marks the request failed, notifies any attached client, and schedules eviction. On `queue`.
+    private func handleFailure() {
+        guard !failed else { return }
+        failed = true
+        task = nil
+        client?.deliverFailed()
+        client = nil
+        scheduleEviction()
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
+                    willCacheResponse proposedResponse: CachedURLResponse,
+                    completionHandler: @escaping (CachedURLResponse?) -> Void) {
+        completionHandler(nil)
     }
 
     /// Cumulative segment end times from `#EXTINF:` lines.
@@ -360,11 +559,5 @@ private final class ProxyConnection: NSObject, URLSessionDataDelegate {
             return nil
         }
         return value
-    }
-
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
-                    willCacheResponse proposedResponse: CachedURLResponse,
-                    completionHandler: @escaping (CachedURLResponse?) -> Void) {
-        completionHandler(nil)
     }
 }

--- a/lib/src/native_video_player_controller.dart
+++ b/lib/src/native_video_player_controller.dart
@@ -47,6 +47,11 @@ class NativeVideoPlayerController with ChangeNotifier {
   /// Emitted when the video has finished playing.
   final onPlaybackEnded = ChangeNotifier();
 
+  /// Emitted when the player resolves the URL it is actually playing from.
+  /// For HLS sources this is the variant playlist URL; reset to null on
+  /// [loadVideoSource].
+  final onPlaybackSourceResolved = ValueNotifier<String?>(null);
+
   /// Emitted when a playback error occurs
   /// or when it's not possible to load the video source
   final onError = ValueNotifier<String?>(null);
@@ -76,6 +81,7 @@ class NativeVideoPlayerController with ChangeNotifier {
       onPlaybackReady: _onPlaybackReady,
       onPlaybackEnded: _onPlaybackEnded,
       onPlaybackPositionChanged: _onPlaybackPositionChanged,
+      onPlaybackSourceResolved: _onPlaybackSourceResolved,
       onError: _onError,
     );
   }
@@ -96,6 +102,11 @@ class NativeVideoPlayerController with ChangeNotifier {
     onError.value = message;
   }
 
+  // ignore: use_setters_to_change_properties
+  void _onPlaybackSourceResolved(String url) {
+    onPlaybackSourceResolved.value = url;
+  }
+
   // NOTE: For internal use only.
   @override
   @protected
@@ -109,6 +120,7 @@ class NativeVideoPlayerController with ChangeNotifier {
   /// NOTE: This method might throw an exception if the video source is invalid.
   Future<void> loadVideoSource(VideoSource videoSource) async {
     await stop();
+    onPlaybackSourceResolved.value = null;
     await _api.loadVideoSource(videoSource);
     _videoSource = videoSource;
   }

--- a/lib/src/native_video_player_view.dart
+++ b/lib/src/native_video_player_view.dart
@@ -38,7 +38,12 @@ class _NativeVideoPlayerViewState extends State<NativeVideoPlayerView> {
   Widget build(BuildContext context) {
     /// RepaintBoundary is a widget that isolates repaints
     return RepaintBoundary(
-      child: _buildNativeView(),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          print('[nvp-size] UiKitView constraints=$constraints');
+          return _buildNativeView();
+        },
+      ),
     );
   }
 

--- a/lib/src/native_video_player_view.dart
+++ b/lib/src/native_video_player_view.dart
@@ -21,7 +21,7 @@ class NativeVideoPlayerView extends StatefulWidget {
   });
 
   @override
-  _NativeVideoPlayerViewState createState() => _NativeVideoPlayerViewState();
+  State<NativeVideoPlayerView> createState() => _NativeVideoPlayerViewState();
 }
 
 class _NativeVideoPlayerViewState extends State<NativeVideoPlayerView> {
@@ -37,14 +37,7 @@ class _NativeVideoPlayerViewState extends State<NativeVideoPlayerView> {
   @override
   Widget build(BuildContext context) {
     /// RepaintBoundary is a widget that isolates repaints
-    return RepaintBoundary(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          print('[nvp-size] UiKitView constraints=$constraints');
-          return _buildNativeView();
-        },
-      ),
-    );
+    return RepaintBoundary(child: _buildNativeView());
   }
 
   Widget _buildNativeView() {

--- a/lib/src/platform_interface/native_video_player_api.dart
+++ b/lib/src/platform_interface/native_video_player_api.dart
@@ -7,6 +7,7 @@ class NativeVideoPlayerApi {
   final void Function() onPlaybackReady;
   final void Function() onPlaybackEnded;
   final void Function(int) onPlaybackPositionChanged;
+  final void Function(String) onPlaybackSourceResolved;
   final void Function(String?) onError;
   late final MethodChannel _channel;
 
@@ -15,6 +16,7 @@ class NativeVideoPlayerApi {
     required this.onPlaybackReady,
     required this.onPlaybackEnded,
     required this.onPlaybackPositionChanged,
+    required this.onPlaybackSourceResolved,
     required this.onError,
   }) {
     final name = 'me.albemala.native_video_player.api.$viewId';
@@ -35,6 +37,9 @@ class NativeVideoPlayerApi {
       case 'onPlaybackPositionChanged':
         final position = call.arguments as int;
         onPlaybackPositionChanged(position);
+      case 'onPlaybackSourceResolved':
+        final url = call.arguments as String;
+        onPlaybackSourceResolved(url);
       case 'onError':
         // final errorCode = call.arguments['errorCode'] as int;
         // final errorMessage = call.arguments['errorMessage'] as String;

--- a/lib/src/platform_interface/native_video_player_api.dart
+++ b/lib/src/platform_interface/native_video_player_api.dart
@@ -28,7 +28,7 @@ class NativeVideoPlayerApi {
     _channel.setMethodCallHandler(null);
   }
 
-  Future<dynamic> _handleMethodCall(MethodCall call) {
+  Future<void> _handleMethodCall(MethodCall call) {
     switch (call.method) {
       case 'onPlaybackReady':
         onPlaybackReady();
@@ -45,8 +45,10 @@ class NativeVideoPlayerApi {
         // final errorMessage = call.arguments['errorMessage'] as String;
         final message = call.arguments as String;
         onError(message);
+      default:
+        throw UnsupportedError('Unrecognized method ${call.method}');
     }
-    throw UnsupportedError('Unrecognized method ${call.method}');
+    return Future.value();
   }
 
   Future<void> loadVideoSource(VideoSource videoSource) async {


### PR DESCRIPTION
### Description

This PR makes the changes needed to properly use HLS in the Immich app for both iOS and Android. As it happens, the iOS `VideoProxyServer` implementation used for mTLS and such ended up being extremely useful here to fill up gaps in the AVPlayer API (setting hints, viewing the playlist segments, and later potentially forcing a particular variant), so it's used in general now. No visible performance regression from this change; it slightly lowered latency if anything.